### PR TITLE
update pip config location according to pip doc

### DIFF
--- a/post/mirror-help/pypi/index.html
+++ b/post/mirror-help/pypi/index.html
@@ -76,7 +76,7 @@
 
 <p>使用方法：</p>
 
-<p>创建或编辑<code>~/.pip/pip.conf</code>文件，加入或修改<code>index-url</code>相关段落为：</p>
+<p>创建或编辑<code>~/.config/pip/pip.conf</code>文件，加入或修改<code>index-url</code>相关段落为：</p>
 
 <pre><code class="language-conf">[global]
 index-url = https://mirrors.sjtug.sjtu.edu.cn/pypi/web/simple


### PR DESCRIPTION
According to <https://pip.pypa.io/en/stable/user_guide/#configuration>, `~/.config/pip/pip.conf` is current path for current versions.
But remain the legacy config sounds reasonable for users who not familiar with pip and use legacy version.